### PR TITLE
Add regular working-time values

### DIFF
--- a/docs/regular-working-time-sources.csv
+++ b/docs/regular-working-time-sources.csv
@@ -1,0 +1,85 @@
+dataset,working_time_weekly,source_url,notes,accessed_on
+Beamte-BW-A,41,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (BW) laut dbb Übersicht,2026-03-24
+Beamte-BW-AW,41,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (BW) laut dbb Übersicht,2026-03-24
+Beamte-BW-B,41,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (BW) laut dbb Übersicht,2026-03-24
+Beamte-BW-W,41,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (BW) laut dbb Übersicht,2026-03-24
+Beamte-Bayern-A,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Bayern) laut dbb Übersicht,2026-03-24
+Beamte-Berlin-A,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Berlin) laut dbb Übersicht,2026-03-24
+Beamte-Berlin-B,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Berlin) laut dbb Übersicht,2026-03-24
+Beamte-Berlin-W,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Berlin) laut dbb Übersicht,2026-03-24
+Beamte-Brandenburg-A,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Brandenburg) laut dbb Übersicht,2026-03-24
+Beamte-Brandenburg-AW,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Brandenburg) laut dbb Übersicht,2026-03-24
+Beamte-Brandenburg-B,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Brandenburg) laut dbb Übersicht,2026-03-24
+Beamte-Brandenburg-W,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Brandenburg) laut dbb Übersicht,2026-03-24
+Beamte-Bremen-A,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Bremen) laut dbb Übersicht,2026-03-24
+Beamte-Bremen-AW,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Bremen) laut dbb Übersicht,2026-03-24
+Beamte-Bremen-B,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Bremen) laut dbb Übersicht,2026-03-24
+Beamte-Bremen-W,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Bremen) laut dbb Übersicht,2026-03-24
+Beamte-Bund-A,41 (40 auf Antrag in Sonderfällen),https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html;https://www.gesetze-im-internet.de/azv/AZV.pdf;https://www.bmi.bund.de/DE/themen/oeffentlicher-dienst/beamtinnen-und-beamte/arbeitszeit/arbeitszeit-artikel.html,Bund: 41h Regelarbeitszeit; 40h auf Antrag in Sonderfällen (dbb/BMI/AZV),2026-03-24
+Beamte-Bund-AW,41 (40 auf Antrag in Sonderfällen),https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html;https://www.gesetze-im-internet.de/azv/AZV.pdf;https://www.bmi.bund.de/DE/themen/oeffentlicher-dienst/beamtinnen-und-beamte/arbeitszeit/arbeitszeit-artikel.html,Bund: 41h Regelarbeitszeit; 40h auf Antrag in Sonderfällen (dbb/BMI/AZV),2026-03-24
+Beamte-Bund-B,41 (40 auf Antrag in Sonderfällen),https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html;https://www.gesetze-im-internet.de/azv/AZV.pdf;https://www.bmi.bund.de/DE/themen/oeffentlicher-dienst/beamtinnen-und-beamte/arbeitszeit/arbeitszeit-artikel.html,Bund: 41h Regelarbeitszeit; 40h auf Antrag in Sonderfällen (dbb/BMI/AZV),2026-03-24
+Beamte-Bund-R,41 (40 auf Antrag in Sonderfällen),https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html;https://www.gesetze-im-internet.de/azv/AZV.pdf;https://www.bmi.bund.de/DE/themen/oeffentlicher-dienst/beamtinnen-und-beamte/arbeitszeit/arbeitszeit-artikel.html,Bund: 41h Regelarbeitszeit; 40h auf Antrag in Sonderfällen (dbb/BMI/AZV),2026-03-24
+Beamte-Bund-W,41 (40 auf Antrag in Sonderfällen),https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html;https://www.gesetze-im-internet.de/azv/AZV.pdf;https://www.bmi.bund.de/DE/themen/oeffentlicher-dienst/beamtinnen-und-beamte/arbeitszeit/arbeitszeit-artikel.html,Bund: 41h Regelarbeitszeit; 40h auf Antrag in Sonderfällen (dbb/BMI/AZV),2026-03-24
+Beamte-Hamburg-A,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Hamburg) laut dbb Übersicht,2026-03-24
+Beamte-Hamburg-AW,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Hamburg) laut dbb Übersicht,2026-03-24
+Beamte-Hamburg-B,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Hamburg) laut dbb Übersicht,2026-03-24
+Beamte-Hamburg-W,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Hamburg) laut dbb Übersicht,2026-03-24
+Beamte-Hessen-A,41 (bis 60) / 40 (ab 61),https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,"Hessen: 41h bis 60, 40h ab 61 (dbb Übersicht)",2026-03-24
+Beamte-Hessen-A-UE,41 (bis 60) / 40 (ab 61),https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,"Hessen: 41h bis 60, 40h ab 61 (dbb Übersicht)",2026-03-24
+Beamte-Hessen-AW,41 (bis 60) / 40 (ab 61),https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,"Hessen: 41h bis 60, 40h ab 61 (dbb Übersicht)",2026-03-24
+Beamte-Hessen-B,41 (bis 60) / 40 (ab 61),https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,"Hessen: 41h bis 60, 40h ab 61 (dbb Übersicht)",2026-03-24
+Beamte-Hessen-W,41 (bis 60) / 40 (ab 61),https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,"Hessen: 41h bis 60, 40h ab 61 (dbb Übersicht)",2026-03-24
+Beamte-LSA-A,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (LSA) laut dbb Übersicht,2026-03-24
+Beamte-LSA-AW,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (LSA) laut dbb Übersicht,2026-03-24
+Beamte-LSA-B,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (LSA) laut dbb Übersicht,2026-03-24
+Beamte-LSA-W,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (LSA) laut dbb Übersicht,2026-03-24
+Beamte-MV-A,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (MV) laut dbb Übersicht,2026-03-24
+Beamte-MV-AW,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (MV) laut dbb Übersicht,2026-03-24
+Beamte-MV-B,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (MV) laut dbb Übersicht,2026-03-24
+Beamte-MV-W,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (MV) laut dbb Übersicht,2026-03-24
+Beamte-NRW-A,41 (bis 54) / 40 (55-59) / 39 (ab 60),https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,"NRW: 41h bis 54, 40h ab 55, 39h ab 60 (dbb Übersicht)",2026-03-24
+Beamte-NRW-B,41 (bis 54) / 40 (55-59) / 39 (ab 60),https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,"NRW: 41h bis 54, 40h ab 55, 39h ab 60 (dbb Übersicht)",2026-03-24
+Beamte-NRW-W,41 (bis 54) / 40 (55-59) / 39 (ab 60),https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,"NRW: 41h bis 54, 40h ab 55, 39h ab 60 (dbb Übersicht)",2026-03-24
+Beamte-Niedersachsen-A,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Niedersachsen) laut dbb Übersicht,2026-03-24
+Beamte-Niedersachsen-B,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Niedersachsen) laut dbb Übersicht,2026-03-24
+Beamte-Niedersachsen-W,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Niedersachsen) laut dbb Übersicht,2026-03-24
+Beamte-RLP-A,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (RLP) laut dbb Übersicht,2026-03-24
+Beamte-RLP-AW,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (RLP) laut dbb Übersicht,2026-03-24
+Beamte-RLP-B,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (RLP) laut dbb Übersicht,2026-03-24
+Beamte-RLP-W,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (RLP) laut dbb Übersicht,2026-03-24
+Beamte-SH-A,41 (40 bei GdB >= 50),https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,"Schleswig-Holstein: 41h, 40h bei Schwerbehinderung (dbb Übersicht)",2026-03-24
+Beamte-SH-B,41 (40 bei GdB >= 50),https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,"Schleswig-Holstein: 41h, 40h bei Schwerbehinderung (dbb Übersicht)",2026-03-24
+Beamte-SH-W,41 (40 bei GdB >= 50),https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,"Schleswig-Holstein: 41h, 40h bei Schwerbehinderung (dbb Übersicht)",2026-03-24
+Beamte-Saarland-A,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Saarland) laut dbb Übersicht,2026-03-24
+Beamte-Saarland-AW,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Saarland) laut dbb Übersicht,2026-03-24
+Beamte-Saarland-B,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Saarland) laut dbb Übersicht,2026-03-24
+Beamte-Saarland-W,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Saarland) laut dbb Übersicht,2026-03-24
+Beamte-Sachsen-A,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Sachsen) laut dbb Übersicht,2026-03-24
+Beamte-Sachsen-B,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Sachsen) laut dbb Übersicht,2026-03-24
+Beamte-Sachsen-W,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Sachsen) laut dbb Übersicht,2026-03-24
+Beamte-Thueringen-A,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Thueringen) laut dbb Übersicht,2026-03-24
+Beamte-Thueringen-AW,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Thueringen) laut dbb Übersicht,2026-03-24
+Beamte-Thueringen-B,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Thueringen) laut dbb Übersicht,2026-03-24
+Beamte-Thueringen-W,40,https://www.dbb.de/lexikon/themenartikel/a/arbeitszeit.html,Regelarbeitszeit für Beamtinnen und Beamte (Thueringen) laut dbb Übersicht,2026-03-24
+MTV-Autobahn,39 / 38.5 (Schichtbereiche),https://www.dbb.de/fileadmin/user_upload/globale_elemente/pdfs/2021/autobahn/1_MTV_Autobahn_dbb.pdf,Regelarbeitszeit laut MTV Autobahn (je nach Bereich),2026-03-24
+TV-BA,39,https://www.arbeitsagentur.de/bakarriere/datei/tarifvertrag_ba020650.pdf,Regelarbeitszeit laut § 6 TV-BA,2026-03-24
+TV-DGUV,39,https://oeffentlicher-dienst.info/bg/;https://www.dguv.de/karriere/index.jsp,Regelarbeitszeit laut Tarifvertrag (§ Arbeitszeit),2026-03-24
+TV-DRV,39,https://www.deutsche-rentenversicherung.de/SharedDocs/Downloads/DE/Traeger/Bund/Wir_ueber_uns_und_Presse/Tarifvertraege/2025/tv-drv-bund-20250605.pdf?__blob=publicationFile&v=3,Regelarbeitszeit laut § 6 TV-DRV Bund,2026-03-24
+TV-Dataport,38.7,https://gesundheit-soziales-bildung-nord.verdi.de/++file++659fcec15f1b71823d2368e0/download/TV%20Dataport%20Gesamt%202021.pdf,Regelarbeitszeit laut TV Dataport,2026-03-24
+TV-H,40,https://hessen.dgb.de/service/tarifvertraege/tvh,Regelarbeitszeit laut Tarifvertrag (§ Arbeitszeit),2026-03-24
+TV-H-SuE,40,https://hessen.dgb.de/service/tarifvertraege/tvh,Regelarbeitszeit laut Tarifvertrag (§ Arbeitszeit),2026-03-24
+TV-ITDZ-Berlin,39.4,https://jobs.itdz-berlin.de/content/FAQ/?locale=de_DE,Regelarbeitszeit ITDZ Berlin (FAQ),2026-03-24
+TV-ITZBund,39,https://www.dbb.de/fileadmin/user_upload/globale_elemente/pdfs/2023/231121_Entgelttabelle_Bund_ab_Maerz_2024_inkl._Stundenentgelte.pdf,Regelarbeitszeit laut Tarifvertrag (§ Arbeitszeit),2026-03-24
+TV-L,je nach Bundesland (39.0-40.0),https://oeffentlicher-dienst.info/tv-l/allg/arbeitszeit.html,"Arbeitszeiten je Bundesland; Tarifgebiet Ost 40,0h",2026-03-24
+TV-L-KR,je nach Bundesland (39.0-40.0),https://oeffentlicher-dienst.info/tv-l/allg/arbeitszeit.html,"Arbeitszeiten je Bundesland; Tarifgebiet Ost 40,0h",2026-03-24
+TV-L-S,je nach Bundesland (39.0-40.0),https://oeffentlicher-dienst.info/tv-l/allg/arbeitszeit.html,"Arbeitszeiten je Bundesland; Tarifgebiet Ost 40,0h",2026-03-24
+TV-N-Bayern,38.5,https://www.swm.de/dam/doc/karriere/tv-n.pdf,Regelarbeitszeit laut Tarifvertrag (§ Arbeitszeit),2026-03-24
+TV-N-Berlin,37.5,https://www.gklberlin.de/fileadmin/user_upload/www_gklberlin_de/pdf/17._AETV_TV-N_Berlin.pdf,Regelarbeitszeit seit 01.07.2024 laut Änderungstarifvertrag,2026-03-24
+TV-N-NRW,39,https://www.verdi.de/++file++6482cf3e4856c398472d49ef/download/3905_116_Tab_TV-N%20BW_NW_NDS_Tarifeinigung.pdf,Regelarbeitszeit laut Tarifvertrag (§ Arbeitszeit),2026-03-24
+TV-V,39 / 40 (bestimmte Gruppen),https://www.vka.de/assets/media/docs/0/Tarifverträge/TV-V_idF_ÄTV_13.pdf,Regelarbeitszeit laut § 8 TV-V (je nach Beschäftigtengruppe),2026-03-24
+TV-Ärzte,42,https://www.marburger-bund.de/sites/default/files/tarifvertraege/2020-06/20-06-02%20TV-%C3%84rzte%20i.d.F.%207.%C3%84nderungsTV.pdf,Regelarbeitszeit laut TV-Ärzte TdL,2026-03-24
+TVöD-Bund,39,https://www.bmi.bund.de/SharedDocs/downloads/DE/veroeffentlichungen/themen/oeffentlicher-dienst/tarifvertraege/tvoed.pdf?__blob=publicationFile&v=8,Regelarbeitszeit laut § 6 TVöD,2026-03-24
+TVöD-P,39,https://www.bmi.bund.de/DE/themen/oeffentlicher-dienst/tarifvertraege/tvoed/tvoed-node.html,Regelarbeitszeit laut Tarifvertrag (§ Arbeitszeit),2026-03-24
+TVöD-S,39,https://www.bmi.bund.de/DE/themen/oeffentlicher-dienst/tarifvertraege/tvoed/tvoed-node.html,Regelarbeitszeit laut Tarifvertrag (§ Arbeitszeit),2026-03-24
+TVöD-SuE,39,https://www.bmi.bund.de/DE/themen/oeffentlicher-dienst/tarifvertraege/tvoed/tvoed-node.html,Regelarbeitszeit laut Tarifvertrag (§ Arbeitszeit),2026-03-24
+TVöD-VKA,39,https://www.kommunalforum.de/tvoed_regelmaessige_arbeitszeit.php,Regelarbeitszeit laut § 6 TVöD-VKA,2026-03-24

--- a/tables/Beamte-BW-A/Meta.csv
+++ b/tables/Beamte-BW-A/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,A
 valid_from,2025.02.01
+working_time_weekly,41
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Landesbesoldungsordnung A Baden-Württemberg
 name_en,Baden-Württemberg Salary Scale A

--- a/tables/Beamte-BW-AW/Meta.csv
+++ b/tables/Beamte-BW-AW/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,AW
 valid_from,2025.02.01
+working_time_weekly,41
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Anwärtergrundbetrag Baden-Württemberg
 name_en,Baden-Württemberg Candidate Base Amount

--- a/tables/Beamte-BW-B/Meta.csv
+++ b/tables/Beamte-BW-B/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,B
 valid_from,2025.02.01
+working_time_weekly,41
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Landesbesoldungsordnung B Baden-Württemberg
 name_en,Baden-Württemberg Salary Scale B

--- a/tables/Beamte-BW-W/Meta.csv
+++ b/tables/Beamte-BW-W/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,W
 valid_from,2025.02.01
+working_time_weekly,41
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Landesbesoldungsordnung W Baden-Württemberg
 name_en,Baden-Württemberg Salary Scale W

--- a/tables/Beamte-Bayern-A/Meta.csv
+++ b/tables/Beamte-Bayern-A/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,A
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Besoldungsordnung A Bayern
 name_en,Bavaria Salary Scale A

--- a/tables/Beamte-Berlin-A/Meta.csv
+++ b/tables/Beamte-Berlin-A/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,A
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Landesbesoldungsordnung Berlin A
 name_en,Berlin State Salary Scale A

--- a/tables/Beamte-Berlin-B/Meta.csv
+++ b/tables/Beamte-Berlin-B/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,B
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Landesbesoldungsordnung Berlin B
 name_en,Berlin State Salary Scale B

--- a/tables/Beamte-Berlin-W/Meta.csv
+++ b/tables/Beamte-Berlin-W/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,W
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Landesbesoldungsordnung Berlin W
 name_en,Berlin State Salary Scale W

--- a/tables/Beamte-Brandenburg-A/Meta.csv
+++ b/tables/Beamte-Brandenburg-A/Meta.csv
@@ -1,10 +1,11 @@
 key,value
 pay_grad_name,A
 valid_from,2024.07.01
+working_time_weekly,40
 link,https://www.dbb.de/fileadmin/user_upload/globale_elemente/pdfs/2024/besoldungstabellen/Land_Brandenburg_01072024.pdf
 name_de,Landesbesoldungsordnung A Brandenburg
 name_en,State Salary Scale A Brandenburg
 prv,
 allowances,brandenburg-family-allowance;brandenburg-family-special-allowance;brandenburg-position-allowances;brandenburg-official-allowances-A;brandenburg-duz;brandenburg-overtime
-entgeltregelungen_de,"Seit 2013 sind 21 € monatlich in das Grundgehalt integriert; für Anwärter beträgt der integrierte Anteil 10 €."
+entgeltregelungen_de,Seit 2013 sind 21 € monatlich in das Grundgehalt integriert; für Anwärter beträgt der integrierte Anteil 10 €.
 entgeltregelungen_en,"Since 2013, €21 per month is integrated into base salary; for candidates the integrated portion is €10."

--- a/tables/Beamte-Brandenburg-AW/Meta.csv
+++ b/tables/Beamte-Brandenburg-AW/Meta.csv
@@ -1,10 +1,11 @@
 key,value
 pay_grad_name,AW
 valid_from,2024.07.01
+working_time_weekly,40
 link,https://www.dbb.de/fileadmin/user_upload/globale_elemente/pdfs/2024/besoldungstabellen/Land_Brandenburg_01072024.pdf
 name_de,Anwärtergrundbetrag Brandenburg
 name_en,Candidate Base Amount Brandenburg
 prv,
 allowances,brandenburg-family-allowance
-entgeltregelungen_de,"Seit 2013 sind 21 € monatlich in das Grundgehalt integriert; für Anwärter beträgt der integrierte Anteil 10 €."
+entgeltregelungen_de,Seit 2013 sind 21 € monatlich in das Grundgehalt integriert; für Anwärter beträgt der integrierte Anteil 10 €.
 entgeltregelungen_en,"Since 2013, €21 per month is integrated into base salary; for candidates the integrated portion is €10."

--- a/tables/Beamte-Brandenburg-B/Meta.csv
+++ b/tables/Beamte-Brandenburg-B/Meta.csv
@@ -1,10 +1,11 @@
 key,value
 pay_grad_name,B
 valid_from,2024.07.01
+working_time_weekly,40
 link,https://www.dbb.de/fileadmin/user_upload/globale_elemente/pdfs/2024/besoldungstabellen/Land_Brandenburg_01072024.pdf
 name_de,Landesbesoldungsordnung B Brandenburg
 name_en,State Salary Scale B Brandenburg
 prv,
 allowances,brandenburg-family-allowance;brandenburg-position-allowances
-entgeltregelungen_de,"Seit 2013 sind 21 € monatlich in das Grundgehalt integriert; für Anwärter beträgt der integrierte Anteil 10 €."
+entgeltregelungen_de,Seit 2013 sind 21 € monatlich in das Grundgehalt integriert; für Anwärter beträgt der integrierte Anteil 10 €.
 entgeltregelungen_en,"Since 2013, €21 per month is integrated into base salary; for candidates the integrated portion is €10."

--- a/tables/Beamte-Brandenburg-W/Meta.csv
+++ b/tables/Beamte-Brandenburg-W/Meta.csv
@@ -1,10 +1,11 @@
 key,value
 pay_grad_name,W
 valid_from,2024.10.01
+working_time_weekly,40
 link,https://www.dbb.de/fileadmin/user_upload/globale_elemente/pdfs/2024/besoldungstabellen/Land_Brandenburg_01072024.pdf
 name_de,Landesbesoldungsordnung W Brandenburg
 name_en,State Salary Scale W Brandenburg
 prv,
 allowances,brandenburg-family-allowance
-entgeltregelungen_de,"Werte gültig ab 01.10.2024 gemäß Tabelle 07/2024; die Werte 01.07.2024 bis 30.09.2024 sind im Archiv abgelegt."
-entgeltregelungen_en,"Values valid from 2024-10-01 according to the 07/2024 table; values for 2024-07-01 to 2024-09-30 are stored in archive."
+entgeltregelungen_de,Werte gültig ab 01.10.2024 gemäß Tabelle 07/2024; die Werte 01.07.2024 bis 30.09.2024 sind im Archiv abgelegt.
+entgeltregelungen_en,Values valid from 2024-10-01 according to the 07/2024 table; values for 2024-07-01 to 2024-09-30 are stored in archive.

--- a/tables/Beamte-Bremen-A/Meta.csv
+++ b/tables/Beamte-Bremen-A/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,A
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.finanzen.bremen.de
 name_de,Besoldungsordnung A (Bremen)
 name_en,Salary Scale A (Bremen)

--- a/tables/Beamte-Bremen-AW/Meta.csv
+++ b/tables/Beamte-Bremen-AW/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,AW
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.finanzen.bremen.de
 name_de,Anwärtergrundbetrag (Bremen)
 name_en,Candidate Basic Amount (Bremen)

--- a/tables/Beamte-Bremen-B/Meta.csv
+++ b/tables/Beamte-Bremen-B/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,B
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.finanzen.bremen.de
 name_de,Besoldungsordnung B (Bremen)
 name_en,Salary Scale B (Bremen)

--- a/tables/Beamte-Bremen-W/Meta.csv
+++ b/tables/Beamte-Bremen-W/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,W
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.finanzen.bremen.de
 name_de,Besoldungsordnung W (Bremen)
 name_en,Salary Scale W (Bremen)

--- a/tables/Beamte-Bund-A/Meta.csv
+++ b/tables/Beamte-Bund-A/Meta.csv
@@ -1,7 +1,8 @@
 key,value
 pay_grad_name,A
 valid_from,2025.04.01
-link,"https://www.gesetze-im-internet.de/bbesg/BJNR011740975.html"
+working_time_weekly,41 (40 auf Antrag in Sonderfällen)
+link,https://www.gesetze-im-internet.de/bbesg/BJNR011740975.html
 name_de,Bundesbesoldungsordnung A
 name_en,Federal Salary Scale A
 prv,

--- a/tables/Beamte-Bund-AW/Meta.csv
+++ b/tables/Beamte-Bund-AW/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,AW
 valid_from,2025.04.01
+working_time_weekly,41 (40 auf Antrag in Sonderfällen)
 link,https://www.gesetze-im-internet.de/bbesg/BJNR011740975.html
 name_de,Anwärtergrundbetrag
 name_en,Candidate Base Amount

--- a/tables/Beamte-Bund-B/Meta.csv
+++ b/tables/Beamte-Bund-B/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,B
 valid_from,2025.04.01
+working_time_weekly,41 (40 auf Antrag in Sonderfällen)
 link,http://www.bgbl.de/xaver/bgbl/start.xav?startbk=Bundesanzeiger_BGBl&jumpTo=bgbl121s2444.pdf
 name_de,Bundesbesoldungsordnung B
 name_en,Federal Salary Scale B

--- a/tables/Beamte-Bund-R/Meta.csv
+++ b/tables/Beamte-Bund-R/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,R
 valid_from,2025.04.01
+working_time_weekly,41 (40 auf Antrag in Sonderfällen)
 link,http://www.bgbl.de/xaver/bgbl/start.xav?startbk=Bundesanzeiger_BGBl&jumpTo=bgbl121s2444.pdf
 name_de,Bundesbesoldungsordnung R
 name_en,Federal Salary Scale R

--- a/tables/Beamte-Bund-W/Meta.csv
+++ b/tables/Beamte-Bund-W/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,W
 valid_from,2025.04.01
+working_time_weekly,41 (40 auf Antrag in Sonderfällen)
 link,http://www.bgbl.de/xaver/bgbl/start.xav?startbk=Bundesanzeiger_BGBl&jumpTo=bgbl121s2444.pdf
 name_de,Bundesbesoldungsordnung W
 name_en,Federal Salary Scale W

--- a/tables/Beamte-Hamburg-A/Meta.csv
+++ b/tables/Beamte-Hamburg-A/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,A
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Hamburgische Besoldungsordnung A
 name_en,Hamburg Salary Scale A

--- a/tables/Beamte-Hamburg-AW/Meta.csv
+++ b/tables/Beamte-Hamburg-AW/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,AW
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Hamburg Anwärtergrundbetrag
 name_en,Hamburg Candidate Base Amount

--- a/tables/Beamte-Hamburg-B/Meta.csv
+++ b/tables/Beamte-Hamburg-B/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,B
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Hamburgische Besoldungsordnung B
 name_en,Hamburg Salary Scale B

--- a/tables/Beamte-Hamburg-W/Meta.csv
+++ b/tables/Beamte-Hamburg-W/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,W
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Hamburgische Besoldungsordnung W
 name_en,Hamburg Salary Scale W

--- a/tables/Beamte-Hessen-A-UE/Meta.csv
+++ b/tables/Beamte-Hessen-A-UE/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,A-UE
 valid_from,2025.12.01
+working_time_weekly,41 (bis 60) / 40 (ab 61)
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Hessische Besoldungsordnung A (Überleitungstabelle)
 name_en,Hesse Salary Scale A (Transition Table)

--- a/tables/Beamte-Hessen-A/Meta.csv
+++ b/tables/Beamte-Hessen-A/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,A
 valid_from,2025.12.01
+working_time_weekly,41 (bis 60) / 40 (ab 61)
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Hessische Besoldungsordnung A (Neuverbeamtung)
 name_en,Hesse Salary Scale A (New Appointment)

--- a/tables/Beamte-Hessen-AW/Meta.csv
+++ b/tables/Beamte-Hessen-AW/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,AW
 valid_from,2025.12.01
+working_time_weekly,41 (bis 60) / 40 (ab 61)
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Anwärtergrundbetrag Hessen
 name_en,Candidate Base Amount Hesse

--- a/tables/Beamte-Hessen-B/Meta.csv
+++ b/tables/Beamte-Hessen-B/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,B
 valid_from,2025.12.01
+working_time_weekly,41 (bis 60) / 40 (ab 61)
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Hessische Besoldungsordnung B
 name_en,Hesse Salary Scale B

--- a/tables/Beamte-Hessen-W/Meta.csv
+++ b/tables/Beamte-Hessen-W/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,W
 valid_from,2025.12.01
+working_time_weekly,41 (bis 60) / 40 (ab 61)
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Hessische Besoldungsordnung W
 name_en,Hesse Salary Scale W

--- a/tables/Beamte-LSA-A/Meta.csv
+++ b/tables/Beamte-LSA-A/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,A
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Landesbesoldungsordnung A Sachsen-Anhalt
 name_en,State Salary Scale A Saxony-Anhalt

--- a/tables/Beamte-LSA-AW/Meta.csv
+++ b/tables/Beamte-LSA-AW/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,AW
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Anwärtergrundbetrag Sachsen-Anhalt
 name_en,Candidate Base Amount Saxony-Anhalt

--- a/tables/Beamte-LSA-B/Meta.csv
+++ b/tables/Beamte-LSA-B/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,B
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Landesbesoldungsordnung B Sachsen-Anhalt
 name_en,State Salary Scale B Saxony-Anhalt

--- a/tables/Beamte-LSA-W/Meta.csv
+++ b/tables/Beamte-LSA-W/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,W
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Besoldungsordnung W Sachsen-Anhalt
 name_en,Salary Scale W Saxony-Anhalt

--- a/tables/Beamte-MV-A/Meta.csv
+++ b/tables/Beamte-MV-A/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,A
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Landesbesoldungsordnung A Mecklenburg-Vorpommern
 name_en,State Salary Scale A Mecklenburg-Vorpommern

--- a/tables/Beamte-MV-AW/Meta.csv
+++ b/tables/Beamte-MV-AW/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,AW
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Anwärtergrundbetrag Mecklenburg-Vorpommern
 name_en,Candidate Basic Amount Mecklenburg-Vorpommern

--- a/tables/Beamte-MV-B/Meta.csv
+++ b/tables/Beamte-MV-B/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,B
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Landesbesoldungsordnung B Mecklenburg-Vorpommern
 name_en,State Salary Scale B Mecklenburg-Vorpommern

--- a/tables/Beamte-MV-W/Meta.csv
+++ b/tables/Beamte-MV-W/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,W
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Besoldungsordnung W Mecklenburg-Vorpommern
 name_en,Salary Scale W Mecklenburg-Vorpommern

--- a/tables/Beamte-NRW-A/Meta.csv
+++ b/tables/Beamte-NRW-A/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,A
 valid_from,2025.02.01
+working_time_weekly,41 (bis 54) / 40 (55-59) / 39 (ab 60)
 link,https://www.finanzverwaltung.nrw.de/dienststellen/landesamt-fuer-besoldung-und-versorgung-nrw/besoldungstabellen
 name_de,Landesbesoldungsordnung A Nordrhein-Westfalen
 name_en,North Rhine-Westphalia Salary Scale A

--- a/tables/Beamte-NRW-B/Meta.csv
+++ b/tables/Beamte-NRW-B/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,B
 valid_from,2025.02.01
+working_time_weekly,41 (bis 54) / 40 (55-59) / 39 (ab 60)
 link,https://www.finanzverwaltung.nrw.de/dienststellen/landesamt-fuer-besoldung-und-versorgung-nrw/besoldungstabellen
 name_de,Landesbesoldungsordnung B Nordrhein-Westfalen
 name_en,North Rhine-Westphalia Salary Scale B

--- a/tables/Beamte-NRW-W/Meta.csv
+++ b/tables/Beamte-NRW-W/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,W
 valid_from,2025.02.01
+working_time_weekly,41 (bis 54) / 40 (55-59) / 39 (ab 60)
 link,https://www.finanzverwaltung.nrw.de/dienststellen/landesamt-fuer-besoldung-und-versorgung-nrw/besoldungstabellen
 name_de,Landesbesoldungsordnung W Nordrhein-Westfalen
 name_en,North Rhine-Westphalia Salary Scale W

--- a/tables/Beamte-Niedersachsen-A/Meta.csv
+++ b/tables/Beamte-Niedersachsen-A/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,A
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Niedersächsische Besoldungsordnung A
 name_en,Lower Saxony Salary Scale A

--- a/tables/Beamte-Niedersachsen-B/Meta.csv
+++ b/tables/Beamte-Niedersachsen-B/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,B
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Niedersächsische Besoldungsordnung B
 name_en,Lower Saxony Salary Scale B

--- a/tables/Beamte-Niedersachsen-W/Meta.csv
+++ b/tables/Beamte-Niedersachsen-W/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,W
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Niedersächsische Besoldungsordnung W
 name_en,Lower Saxony Salary Scale W

--- a/tables/Beamte-RLP-A/Meta.csv
+++ b/tables/Beamte-RLP-A/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,A
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Landesbesoldungsordnung A Rheinland-Pfalz
 name_en,State Salary Scale A Rhineland-Palatinate

--- a/tables/Beamte-RLP-AW/Meta.csv
+++ b/tables/Beamte-RLP-AW/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,AW
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Anwärtergrundbetrag Rheinland-Pfalz
 name_en,Candidate Basic Amount Rhineland-Palatinate

--- a/tables/Beamte-RLP-B/Meta.csv
+++ b/tables/Beamte-RLP-B/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,B
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Landesbesoldungsordnung B Rheinland-Pfalz
 name_en,State Salary Scale B Rhineland-Palatinate

--- a/tables/Beamte-RLP-W/Meta.csv
+++ b/tables/Beamte-RLP-W/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,W
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Besoldungsordnung W Rheinland-Pfalz
 name_en,Salary Scale W Rhineland-Palatinate

--- a/tables/Beamte-SH-A/Meta.csv
+++ b/tables/Beamte-SH-A/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,A
 valid_from,2024.11.01
+working_time_weekly,41 (40 bei GdB >= 50)
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Landesbesoldungsordnung Schleswig-Holstein A
 name_en,Schleswig-Holstein Salary Scale A

--- a/tables/Beamte-SH-B/Meta.csv
+++ b/tables/Beamte-SH-B/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,B
 valid_from,2024.11.01
+working_time_weekly,41 (40 bei GdB >= 50)
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Landesbesoldungsordnung Schleswig-Holstein B
 name_en,Schleswig-Holstein Salary Scale B

--- a/tables/Beamte-SH-W/Meta.csv
+++ b/tables/Beamte-SH-W/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,W
 valid_from,2024.11.01
+working_time_weekly,41 (40 bei GdB >= 50)
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Landesbesoldungsordnung Schleswig-Holstein W
 name_en,Schleswig-Holstein Salary Scale W

--- a/tables/Beamte-Saarland-A/Meta.csv
+++ b/tables/Beamte-Saarland-A/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,A
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Saarländische Besoldungsordnung A
 name_en,Saarland Salary Scale A

--- a/tables/Beamte-Saarland-AW/Meta.csv
+++ b/tables/Beamte-Saarland-AW/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,AW
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Anwärterbezüge Saarland
 name_en,Candidate Pay Saarland

--- a/tables/Beamte-Saarland-B/Meta.csv
+++ b/tables/Beamte-Saarland-B/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,B
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Saarländische Besoldungsordnung B
 name_en,Saarland Salary Scale B

--- a/tables/Beamte-Saarland-W/Meta.csv
+++ b/tables/Beamte-Saarland-W/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,W
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Saarländische Besoldungsordnung W
 name_en,Saarland Salary Scale W

--- a/tables/Beamte-Sachsen-A/Meta.csv
+++ b/tables/Beamte-Sachsen-A/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,A
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Sächsische Besoldungsordnung A
 name_en,Saxony Salary Scale A

--- a/tables/Beamte-Sachsen-B/Meta.csv
+++ b/tables/Beamte-Sachsen-B/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,B
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Sächsische Besoldungsordnung B
 name_en,Saxony Salary Scale B

--- a/tables/Beamte-Sachsen-W/Meta.csv
+++ b/tables/Beamte-Sachsen-W/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,W
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://www.dbb.de/beamtinnen-beamte/besoldungstabellen.html
 name_de,Sächsische Besoldungsordnung W
 name_en,Saxony Salary Scale W

--- a/tables/Beamte-Thueringen-A/Meta.csv
+++ b/tables/Beamte-Thueringen-A/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,A
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://finanzen.thueringen.de/themen/landeshaushalt/besoldung-und-versorgung
 name_de,Besoldungsordnung A Freistaat Thüringen
 name_en,Salary Scale A Free State of Thuringia

--- a/tables/Beamte-Thueringen-AW/Meta.csv
+++ b/tables/Beamte-Thueringen-AW/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,AW
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://finanzen.thueringen.de/themen/landeshaushalt/besoldung-und-versorgung
 name_de,Anwärtergrundbetrag Freistaat Thüringen
 name_en,Candidate Base Amount Free State of Thuringia

--- a/tables/Beamte-Thueringen-B/Meta.csv
+++ b/tables/Beamte-Thueringen-B/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,B
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://finanzen.thueringen.de/themen/landeshaushalt/besoldung-und-versorgung
 name_de,Besoldungsordnung B Freistaat Thüringen
 name_en,Salary Scale B Free State of Thuringia

--- a/tables/Beamte-Thueringen-W/Meta.csv
+++ b/tables/Beamte-Thueringen-W/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,W
 valid_from,2025.02.01
+working_time_weekly,40
 link,https://finanzen.thueringen.de/themen/landeshaushalt/besoldung-und-versorgung
 name_de,Besoldungsordnung W Freistaat Thüringen
 name_en,Salary Scale W Free State of Thuringia

--- a/tables/MTV-Autobahn/Meta.csv
+++ b/tables/MTV-Autobahn/Meta.csv
@@ -1,7 +1,8 @@
 name,value
 pay_grad_name,E
 valid_from,2025.04.01
-link,"https://www.autobahn.de/storage/user_upload/qbank/240301_Entgeltwerte_Autobahn.pdf"
+working_time_weekly,39 / 38.5 (Schichtbereiche)
+link,https://www.autobahn.de/storage/user_upload/qbank/240301_Entgeltwerte_Autobahn.pdf
 name_de,Manteltarifvertrag der Autobahn GmbH des Bundes
 name_en,Collective Agreement for the Autobahn GmbH of the federal government
 allowances,mtv-annual-bonus

--- a/tables/TV-BA/Meta.csv
+++ b/tables/TV-BA/Meta.csv
@@ -3,6 +3,7 @@ name_en,Collective Agreement for Federal Employment Agency
 name_de,Tarifvertrag für Bundesagentur für Arbeit
 pay_grad_name,TE
 valid_from,2026.05.01
+working_time_weekly,39
 link,https://www.arbeitsagentur.de/bakarriere/ba-tarifvertrag
 prv,vbl-west;vbl-east;vbl-west-n-atv;vbl-east-n-atv;kvbw
 allowances,tv-ba-function-allowance-1-2024;tv-ba-function-allowance-2-2024;tv-ba-annual-bonus

--- a/tables/TV-DGUV/Meta.csv
+++ b/tables/TV-DGUV/Meta.csv
@@ -1,10 +1,11 @@
 name,value
 pay_grad_name,E
 valid_from,2026.05.01
+working_time_weekly,39
 link,https://oeffentlicher-dienst.info/bg/;https://www.dguv.de/karriere/index.jsp
 name_de,Tarifvertrag DGUV / BG-AT
 name_en,Collective Agreement DGUV / BG-AT
 prv,vbl-west;vbl-east;vbl-west-n-atv;vbl-east-n-atv
 allowances,dguv-annual-bonus
-entgeltregelungen_de,"Entgelttabelle BG-AT (gültig ab 01.05.2026); Jahressonderzahlung 100% laut DGUV-Karriereportal; leistungsorientierte Bezahlung als weiterer Entgeltbestandteil"
-entgeltregelungen_en,"BG-AT pay table (valid from 2026-05-01); annual bonus 100% according to DGUV career portal; performance-related pay as additional compensation component"
+entgeltregelungen_de,Entgelttabelle BG-AT (gültig ab 01.05.2026); Jahressonderzahlung 100% laut DGUV-Karriereportal; leistungsorientierte Bezahlung als weiterer Entgeltbestandteil
+entgeltregelungen_en,BG-AT pay table (valid from 2026-05-01); annual bonus 100% according to DGUV career portal; performance-related pay as additional compensation component

--- a/tables/TV-DRV/Meta.csv
+++ b/tables/TV-DRV/Meta.csv
@@ -1,6 +1,7 @@
 name,value
 pay_grad_name,E
 valid_from,2026.05.01
+working_time_weekly,39
 link,https://www.deutsche-rentenversicherung.de/Bund/DE/Ueber-uns/Tarifvertraege/tarifvertraege.html
 name_de,Tarifvertrag Deutsche Rentenversicherung (DRV)
 name_en,Collective Agreement German Pension Insurance (DRV)

--- a/tables/TV-Dataport/Meta.csv
+++ b/tables/TV-Dataport/Meta.csv
@@ -1,6 +1,7 @@
 name,value
 pay_grad_name,E
 valid_from,2025.02.01
+working_time_weekly,38.7
 link,https://www.dataport.de/fileadmin/user_upload/karriere/8._aenderungstarifvertrag_tv-dataport.pdf
 name_de,Entgelttabelle TV Dataport
 name_en,Remuneration table TV Dataport

--- a/tables/TV-H-SuE/Meta.csv
+++ b/tables/TV-H-SuE/Meta.csv
@@ -1,6 +1,7 @@
 name,value
 pay_grad_name,S
 valid_from,2025.08.01
+working_time_weekly,40
 link,https://innen.hessen.de/sites/innen.hessen.de/files/2023-01/tv-h_fassung_aendtv_nr._20_vom_15.10.2021.pdf
 name_en,Collective Agreement for Employees in the Social and Educational Services of the State of Hesse
 name_de,Tarifvertrag für die Beschäftigten im Sozial- und Erziehungsdienst des Landes Hessen

--- a/tables/TV-H/Meta.csv
+++ b/tables/TV-H/Meta.csv
@@ -1,6 +1,7 @@
 name,value
 pay_grad_name,E
 valid_from,2025.08.01
+working_time_weekly,40
 link,https://innen.hessen.de/sites/innen.hessen.de/files/2023-01/tv-h_fassung_aendtv_nr._20_vom_15.10.2021.pdf
 name_en,Collective Agreement for the State of Hesse
 name_de,Tarifvertrag für den Öffentlichen Dienst des Landes Hessen

--- a/tables/TV-ITDZ-Berlin/Meta.csv
+++ b/tables/TV-ITDZ-Berlin/Meta.csv
@@ -1,6 +1,7 @@
 name,value
 pay_grad_name,E
 valid_from,2025.02.01
+working_time_weekly,39.4
 link,https://jobs.itdz-berlin.de/content/Verguetung/?locale=de_DE
 name_de,Tarifvertrag ITDZ Berlin
 name_en,Collective Agreement ITDZ Berlin

--- a/tables/TV-ITZBund/Meta.csv
+++ b/tables/TV-ITZBund/Meta.csv
@@ -1,6 +1,7 @@
 name,value
 pay_grad_name,E
 valid_from,2026.05.01
+working_time_weekly,39
 link,https://www.dbb.de/fileadmin/user_upload/globale_elemente/pdfs/2023/231121_Entgelttabelle_Bund_ab_Maerz_2024_inkl._Stundenentgelte.pdf
 name_de,Tarifvertrag ITZBund
 name_en,Collective Agreement ITZBund

--- a/tables/TV-L-KR/Meta.csv
+++ b/tables/TV-L-KR/Meta.csv
@@ -1,6 +1,7 @@
 name,value
 pay_grad_name,KR
 valid_from,2026.04.01
+working_time_weekly,je nach Bundesland (39.0-40.0)
 link,https://www.dbb.de/fileadmin/user_upload/globale_elemente/pdfs/2023/Einkommensrunde_Laender/231209_6_vorlaeufige_Entgelttabelle_TV-L_Anlage_C_Pflege_Februar_2025_bis_Oktober_2025.pdf
 name_de,Tarifvertrag für Pflegekräfte
 name_en,Collective Agreement for the Nursing Profession

--- a/tables/TV-L-S/Meta.csv
+++ b/tables/TV-L-S/Meta.csv
@@ -1,6 +1,7 @@
 name,value
 pay_grad_name,S
 valid_from,2026.04.01
+working_time_weekly,je nach Bundesland (39.0-40.0)
 link,https://www.dbb.de/fileadmin/user_upload/globale_elemente/pdfs/2023/Einkommensrunde_Laender/231209_9_vorlaeufige_Entgelttabelle_TV-L_Anlage_G_Sozial-_und_Erziehungsdienst_Februar_2025_bis_Oktober_2025.pdf
 name_en,Collective Agreement for Employees in the Social and Educational Service
 name_de,Tarifvertrag für Beschäftigte im Sozial- und Erziehungsdienst

--- a/tables/TV-L/Meta.csv
+++ b/tables/TV-L/Meta.csv
@@ -1,6 +1,7 @@
 name,value
 pay_grad_name,E
 valid_from,2026.04.01
+working_time_weekly,je nach Bundesland (39.0-40.0)
 link,https://www.dbb.de/fileadmin/user_upload/globale_elemente/pdfs/2023/Einkommensrunde_Laender/231209_3_vorlaufige_Entgelttabelle_TV-L_Anlage_B_Allgemeiner_Teil_Februar_2025_bis_Oktober_2025.pdf
 name_de,Tarifvertrag Allgemeiner Teil
 name_en,Collective Agreement General Part

--- a/tables/TV-N-Bayern/Meta.csv
+++ b/tables/TV-N-Bayern/Meta.csv
@@ -1,6 +1,7 @@
 name,value
 pay_grad_name,E
 valid_from,2024.03.01
+working_time_weekly,38.5
 link,https://www.swm.de/dam/doc/karriere/tv-n.pdf,
 name_de,Tarifvertrag für den Nahverkehr in Bayern
 name_en,Collective Agreement for Local Transport in Bayern

--- a/tables/TV-N-Berlin/Meta.csv
+++ b/tables/TV-N-Berlin/Meta.csv
@@ -1,7 +1,8 @@
 name,value
 pay_grad_name,E
 valid_from,2026.06.01
-link,"https://static.s123-cdn-static-d.com/uploads/2507629/normal_6218c93cdd77b.pdf"
+working_time_weekly,37.5
+link,https://static.s123-cdn-static-d.com/uploads/2507629/normal_6218c93cdd77b.pdf
 name_de,Tarifvertrag Nahverkehrsunternehmen Berlin
 name_en,Collective Agreement for Public Transport Companies Berlin
 prv,vbl-west;vbl-east;vbl-west-n-atv;vbl-east-n-atv

--- a/tables/TV-N-NRW/Meta.csv
+++ b/tables/TV-N-NRW/Meta.csv
@@ -1,7 +1,8 @@
 name,value
 pay_grad_name,E
 valid_from,2026.05.01
-link,"https://www.verdi.de/++file++6482cf3e4856c398472d49ef/download/3905_116_Tab_TV-N%20BW_NW_NDS_Tarifeinigung.pdf"
+working_time_weekly,39
+link,https://www.verdi.de/++file++6482cf3e4856c398472d49ef/download/3905_116_Tab_TV-N%20BW_NW_NDS_Tarifeinigung.pdf
 name_de,Tarifvertrag Nahverkehr Nordrhein-Westfalen
 name_en,North Rhine-Westphalia Public Transport Collective Agreement
 prv,vbl-west;vbl-east;vbl-west-n-atv;vbl-east-n-atv

--- a/tables/TV-V/Meta.csv
+++ b/tables/TV-V/Meta.csv
@@ -1,6 +1,7 @@
 name,value
 pay_grad_name,E
 valid_from,2026.06.01
+working_time_weekly,39 / 40 (bestimmte Gruppen)
 link,https://www.vka.de/assets/media/docs/0/Tarifvertr%C3%A4ge/230422_TV-V_AETV_17_Lesefassung.pdf
 name_en,Collective Agreement for Public Utilities
 name_de,Tarifvertrag für die Versorgungsbetriebe

--- a/tables/TV-Ärzte/Meta.csv
+++ b/tables/TV-Ärzte/Meta.csv
@@ -1,6 +1,7 @@
 name,value
 pay_grad_name,Ä
 valid_from,2025.02.01
+working_time_weekly,42
 link,https://www.finanzverwaltung.nrw.de/system/files/media/document/file/anlage_2_-_entgelttabelle_tv-aerzte_ab_01.02.2025.pdf
 name_de,Tarifvertrag für Ärztinnen und Ärzte an Universitätskliniken
 name_en,Collective Agreement for Doctors at University Hospitals

--- a/tables/TVöD-Bund/Meta.csv
+++ b/tables/TVöD-Bund/Meta.csv
@@ -1,6 +1,7 @@
 name,value
 pay_grad_name,E
 valid_from,2026.05.01
+working_time_weekly,39
 link,https://www.dbb.de/fileadmin/user_upload/globale_elemente/pdfs/2023/231121_Entgelttabelle_Bund_ab_Maerz_2024_inkl._Stundenentgelte.pdf
 name_de,Tarifvertrag für den öffentlichen Dienst - Bund
 name_en,Collective Agreement for the Public Sector - Federal Government

--- a/tables/TVöD-P/Meta.csv
+++ b/tables/TVöD-P/Meta.csv
@@ -1,6 +1,7 @@
 name,value
 pay_grad_name,P
 valid_from,2026.05.01
+working_time_weekly,39
 link,https://www.verdi.de/++file++6253ed421aba155942c487c4/download/TVOeD_BTB.PDF
 name_de,Tarifvertrag für den öffentlichen Dienst - Pflegedienst
 name_en,Collective Agreement for the Public Sector - Nursing Profession

--- a/tables/TVöD-S/Meta.csv
+++ b/tables/TVöD-S/Meta.csv
@@ -1,6 +1,7 @@
 name,value
 pay_grad_name,E
 valid_from,2026.05.01
+working_time_weekly,39
 link,https://www.verdi.de/++file++6253ed769ddc5ffddf0b8118/download/TVOeD_BTS.PDF
 name_en,Collective Agreement for the Public Service - Sparkassen
 name_de,Tarifvertrag für den öffentlichen Dienst - Sparkassen

--- a/tables/TVöD-SuE/Meta.csv
+++ b/tables/TVöD-SuE/Meta.csv
@@ -1,6 +1,7 @@
 name,value
 pay_grad_name,S
 valid_from,2026.05.01
+working_time_weekly,39
 link,https://www.verdi.de/++file++6253ed421aba155942c487c4/download/TVOeD_BTB.PDF
 name_de,Tarifvertrag für den öffentlichen Dienst - Sozial- und Erziehungsdienst
 name_en,Collective Agreement for the Public Sector - Social and Educational Service

--- a/tables/TVöD-VKA/Meta.csv
+++ b/tables/TVöD-VKA/Meta.csv
@@ -1,6 +1,7 @@
 key,value
 pay_grad_name,E
 valid_from,2026.05.01
+working_time_weekly,39
 link,https://zusammen-geht-mehr.verdi.de/++file++643d66a12f5adb9e88f923da/download/3905_110_01_VKA_A.pdf
 name_de,Tarifvertrag für den öffentlichen Dienst - Vereinigung der kommunalen Arbeitgeberverbände
 name_en,Collective Agreement for the Public Sector - Association of Local Government Employers


### PR DESCRIPTION
### Motivation

- Provide an explicit source list for regular weekly working times used across datasets.
- Make the expected weekly working time explicit in table metadata as working_time_weekly key.

### Description

- Add docs/regular-working-time-sources.csv with provenance, working_time_weekly values, source URLs and access dates for pay datasets.
- Add a working_time_weekly metadata entry to many tables/*/Meta.csv files to record the standard weekly hours per dataset.